### PR TITLE
Create wrapping function and changed stol to stoll

### DIFF
--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -18,6 +18,23 @@
 #include "world/world.hpp"
 
 
+//Wrapper function to check for out of range values
+
+long int wrap(std::string s)
+{
+    try
+    {
+        return (std::stoll(s));
+    }
+    catch(const std::exception& e)
+    {
+        return INT_MAX;
+    }
+    
+    
+}
+
+
 // Constructor, sets up the parser.
 Parser::Parser() : m_special_state(SpecialState::NONE)
 {


### PR DESCRIPTION
Added a ```wrap()``` function to replace the ```stol``` function which can handle out of range exception, also replaced ```stol``` with ```stoll``` in the ```wrap()``` function to handle bigger values. Let me know what you think about it.