### PR TITLE
Added linux support for FileX::is_read_only() function

### DIFF
--- a/src/core/filex.cpp
+++ b/src/core/filex.cpp
@@ -1,5 +1,5 @@
 // core/filex.cpp -- Various utility functions that deal with creating, deleting, and manipulating files.
-// Copyright (c) 2020-2021 Raine "Gravecat" Simmons. Licensed under the GNU Affero General Public License v3 or any later version.
+// Copyright (c) 2020-2021 Raine "Gravecat" Simmons and the Greave contributors. Licensed under the GNU Affero General Public License v3 or any later version.
 
 #include "core/filex.hpp"
 

--- a/src/core/filex.cpp
+++ b/src/core/filex.cpp
@@ -70,6 +70,8 @@ bool FileX::is_read_only(const std::string &file)
 #ifdef GREAVE_TARGET_WINDOWS
     DWORD attributes = GetFileAttributes(file.c_str());
     if (attributes != INVALID_FILE_ATTRIBUTES) return (attributes & FILE_ATTRIBUTE_READONLY);
+#elif GREAVE_TARGET_LINUX
+    if(access(file.c_str(), R_OK) == 0 && access(file.c_str(), W_OK) != 0) return true;
 #endif
     return false;
 }


### PR DESCRIPTION
What is the purpose of this pull request?
-----------------------------------------
… Adding linux support to the FileX::is_read_only() function

Is it directly linked to an existing, open issue? If so, please link it here.
-----------------------------------------------------------------------------
… https://github.com/Gravecat/Greave/issues/11#issue-937906529

Please confirm that the code being submitted is your own work, and/or is licensed under a GPL-compatible license.
-----------------------------------------------------------------------------------------------------------------
- [x] I have read the [contributing guidelines](https://github.com/Gravecat/Greave/blob/main/.github/CONTRIBUTING.md).
- [x] This code is my own work.
- [x] This code is licensed under a [GPL-compatible license](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).

Any other comments?
-------------------
…
