### PR TITLE
Stamina regen penalty when bloated

### DIFF
--- a/src/core/core-constants.h
+++ b/src/core/core-constants.h
@@ -9,7 +9,7 @@
 
 struct CoreConstants
 {
-    static constexpr uint32_t   SAVE_VERSION =      82;     // The version number for saved game files. This should increment when old saves can no longer be loaded.
+    static constexpr uint32_t   SAVE_VERSION =      83;     // The version number for saved game files. This should increment when old saves can no longer be loaded.
     static constexpr uint32_t   TAGS_PERMANENT =    10000;  // The tag number at which tags are considered permanent.
     static const char           GAME_VERSION[];             // The game's version number.
 };

--- a/src/world/player.cc
+++ b/src/world/player.cc
@@ -1,5 +1,5 @@
 // world/player.cc -- The Player class is derived from Mobile, and defines the player character in the game world.
-// Copyright (c) 2021 Raine "Gravecat" Simmons. Licensed under the GNU Affero General Public License v3 or any later version.
+// Copyright (c) 2021 Raine "Gravecat" Simmons and the Greave contributors. Licensed under the GNU Affero General Public License v3 or any later version.
 
 #include <cmath>
 
@@ -9,7 +9,7 @@
 
 
 // The SQL table construction string for the player data.
-constexpr char Player::SQL_PLAYER[] = "CREATE TABLE player ( blood_tox INTEGER, hunger INTEGER NOT NULL, mob_target INTEGER, money INTEGER NOT NULL, mp INTEGER NOT NULL, mp_max INTEGER NOT NULL, sp INTEGER NOT NULL, sp_max INTEGER NOT NULL, sql_id INTEGER PRIMARY KEY UNIQUE NOT NULL, thirst INTEGET NOT NULL )";
+constexpr char Player::SQL_PLAYER[] = "CREATE TABLE player ( blood_tox INTEGER, hunger INTEGER NOT NULL, mob_target INTEGER, money INTEGER NOT NULL, mp INTEGER NOT NULL, mp_max INTEGER NOT NULL, sp INTEGER NOT NULL, sp_delay INTEGER, sp_max INTEGER NOT NULL, sql_id INTEGER PRIMARY KEY UNIQUE NOT NULL, thirst INTEGET NOT NULL )";
 
 // The SQL table construction string for the player skills data.
 constexpr char Player::SQL_SKILLS[] = "CREATE TABLE skills ( id TEXT PRIMARY KEY UNIQUE NOT NULL, level INTEGER NOT NULL, xp REAL )";
@@ -171,6 +171,7 @@ uint32_t Player::load(std::shared_ptr<SQLite::Database> save_db, uint32_t sql_id
         mp_[0] = query.getColumn("mp").getInt();
         mp_[1] = query.getColumn("mp_max").getInt();
         sp_[0] = query.getColumn("sp").getInt();
+        if (!query.isColumnNull("sp_delay")) sp_[2] = query.getColumn("sp_delay").getInt();
         sp_[1] = query.getColumn("sp_max").getInt();
         sql_id = query.getColumn("sql_id").getUInt();
         thirst_ = query.getColumn("thirst").getInt();
@@ -292,7 +293,7 @@ void Player::restore_sp(int amount)
 uint32_t Player::save(std::shared_ptr<SQLite::Database> save_db)
 {
     const uint32_t sql_id = Mobile::save(save_db);
-    SQLite::Statement query(*save_db, "INSERT INTO player ( blood_tox, hunger, mob_target, money, mp, mp_max, sp, sp_max, sql_id, thirst ) VALUES ( :blood_tox, :hunger, :mob_target, :money, :mp, :mp_max, :sp, :sp_max, :sql_id, :thirst )");
+    SQLite::Statement query(*save_db, "INSERT INTO player ( blood_tox, hunger, mob_target, money, mp, mp_max, sp, sp_delay, sp_max, sql_id, thirst ) VALUES ( :blood_tox, :hunger, :mob_target, :money, :mp, :mp_max, :sp, :sp_delay, :sp_max, :sql_id, :thirst )");
     if (blood_tox_) query.bind(":blood_tox", blood_tox_);
     query.bind(":hunger", hunger_);
     if (mob_target_) query.bind(":mob_target", mob_target_);
@@ -300,6 +301,7 @@ uint32_t Player::save(std::shared_ptr<SQLite::Database> save_db)
     query.bind(":mp", mp_[0]);
     query.bind(":mp_max", mp_[1]);
     query.bind(":sp", sp_[0]);
+    if (sp_[2]) query.bind(":sp_delay", sp_[2]);
     query.bind(":sp_max", sp_[1]);
     query.bind(":sql_id", sql_id);
     query.bind(":thirst", thirst_);

--- a/src/world/player.cc
+++ b/src/world/player.cc
@@ -22,6 +22,7 @@ Player::Player() : blood_tox_(0), death_reason_("the will of the gods"), hunger_
     set_name("Player");
     mp_[0] = mp_[1] = MP_DEFAULT;
     sp_[0] = sp_[1] = SP_DEFAULT;
+    sp_[2] = 0;
 }
 
 // Eats food, increasing the hunger counter.
@@ -376,7 +377,14 @@ void Player::tick_hp_regen()
 void Player::tick_mp_regen() { restore_mp(MP_REGEN_PER_TICK); }
 
 // Regenerates SP over time.
-void Player::tick_sp_regen() { restore_sp(SP_REGEN_PER_TICK); }
+void Player::tick_sp_regen() {
+    if(hunger()>HUNGER_MAX){
+        //Integer division means we have to track remainder
+        sp_[2] += SP_REGEN_PER_TICK;
+        restore_sp(sp_[2]/SP_REGEN_BLOAT_DIVISOR);
+        sp_[2] %= SP_REGEN_BLOAT_DIVISOR;
+    } else{restore_sp(SP_REGEN_PER_TICK);}
+}
 
 // Checks if the player is wearing a certain type of armour (light/medium/heavy).
 bool Player::wearing_armour(ItemSub type)

--- a/src/world/player.h
+++ b/src/world/player.h
@@ -1,5 +1,5 @@
 // world/player.h -- The Player class is derived from Mobile, and defines the player character in the game world.
-// Copyright (c) 2021 Raine "Gravecat" Simmons. Licensed under the GNU Affero General Public License v3 or any later version.
+// Copyright (c) 2021 Raine "Gravecat" Simmons and the Greave contributors. Licensed under the GNU Affero General Public License v3 or any later version.
 
 #ifndef GREAVE_WORLD_PLAYER_H_
 #define GREAVE_WORLD_PLAYER_H_

--- a/src/world/player.h
+++ b/src/world/player.h
@@ -77,6 +77,7 @@ private:
     static constexpr float  SKILL_HAULING_DIVISOR =         50;     // This number affects how effective the Hauling skill is at increasing maximum carry weight. LOWER number = skill allows more carry weight.
     static constexpr int    SP_DEFAULT =                    100;    // The default stamina points maximum for the player.
     static constexpr int    SP_REGEN_PER_TICK =             1;      // How much stamina is regenerated each stamina heartbeat tick?
+    static constexpr int    SP_REGEN_BLOAT_DIVISOR =        2;      // How much to divide SP regen by while bloated   
     static constexpr int    THIRST_MAX =                    20;     // The maximum thirst value (when this is maxed, the player is fully quenched.)
     static constexpr float  TOUGHNESS_GAIN_MODIFIER =       10;     // The higher this value, the faster toughness will increase in combat.
 
@@ -90,7 +91,7 @@ private:
     int                             mp_[2];         // The current and maximum mana points.
     std::map<std::string, int>      skill_levels_;  // The skill levels learned by this Player, if any.
     std::map<std::string, float>    skill_xp_;      // The experience levels of skills on this Player, if any.
-    int                             sp_[2];         // The current and maximum stamina points.
+    int                             sp_[3];         // The current,maximum and delayed stamina points.
     uint8_t                         thirst_;        // The thirst counter. 20 = compmpletely hydrated, 0 = died of dehydration.
 };
 


### PR DESCRIPTION
What is the purpose of this pull request?
-----------------------------------------------------------------------------------------------------------------
To add a stamina regen penalty while the player is bloated(Player::hunger() > Player::HUNGER_MAX)

Is it directly linked to an existing, open issue? If so, please link it here.
-----------------------------------------------------------------------------------------------------------------
Yes
[https://github.com/Gravecat/Greave/issues/43]

Please confirm that the code being submitted is your own work, and/or is licensed under a GPL-compatible license.
-----------------------------------------------------------------------------------------------------------------

- [x] I have read the [contributing guidelines](https://github.com/Gravecat/Greave/blob/main/.github/CONTRIBUTING.md).
- [x] This code is my own work.
- [x] This code is licensed under a [GPL-compatible license](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).

Any other comments?
-----------------------------------------------------------------------------------------------------------------
Integer division means that simply adding a divisor greater than 1 will reduce bloated stamina regen to zero.
Added a remainder component to sp_[] which tracks regen erased this way and adds it back in at a later tick.
